### PR TITLE
Win10 - fix mvn test failure

### DIFF
--- a/ekstazi-maven-plugin.test/src/test/resources/ekstazilifecycle/pom.xml
+++ b/ekstazi-maven-plugin.test/src/test/resources/ekstazilifecycle/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.10</version>
+        <version>4.13.1</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/org.ekstazi.core.test/src/main/java/org/ekstazi/it/AbstractCmd.java
+++ b/org.ekstazi.core.test/src/main/java/org/ekstazi/it/AbstractCmd.java
@@ -46,6 +46,9 @@ public abstract class AbstractCmd {
     public final void execute() {
         try {
             String[] command = getCommand();
+            if (System.getProperty("os.name").toLowerCase().contains("win") && command[0].equals("mvn") {
+                command[0] = "mvn.cmd";
+            }
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.directory(mCwd);
             pb.redirectErrorStream(true);


### PR DESCRIPTION
In `ekstazi\org.ekstazi.core.test\src\main\java\org\ekstazi\it\AbstractCmd.java`, the generated maven commands will start with "mvn ...". However on Windows, directly apply this command will raise a problem ([link](https://stackoverflow.com/questions/14288185/detecting-windows-or-linux)).

We add 3 lines to `AbstractCmd.java` at line 49.

```Java
if (System.getProperty("os.name").toLowerCase().contains("win") && command[0].equals("mvn"){
	command[0] = "mvn.cmd";
}
```