### PR TITLE
[BUG] `force.all` and `force.failing` do not work with Maven mode

### DIFF
--- a/ekstazi-maven-plugin/src/main/java/org/ekstazi/maven/StaticSelectEkstaziMojo.java
+++ b/ekstazi-maven-plugin/src/main/java/org/ekstazi/maven/StaticSelectEkstaziMojo.java
@@ -62,23 +62,6 @@ public class StaticSelectEkstaziMojo extends AbstractEkstaziMojo {
     private static final String[] sNonSupportedVersions = {"2.0-beta-1", "2.0", "2.1", "2.1.1", "2.1.2", "2.1.3", "2.2", "2.3", "2.3.1", "2.4", "2.4.1", "2.4.2", "2.4.3", "2.5", "2.6", "2.7", "2.7.1", "2.7.2", "2.8", "2.8.1", "2.9", "2.10", "2.11", "2.12", "2.12.1", "2.12.2", "2.12.3", "2.12.4"};
 
     /**
-     * Enable/disable forcing run of tests that failed last time they
-     * were run.
-     *
-     * @since 4.1.0
-     */
-    @Parameter(property = "ekstazi.forcefailing", defaultValue = "false")
-    private boolean forcefailing;
-
-    /**
-     * Enable/disable forcing run of all tests.
-     *
-     * @since 4.3.0
-     */
-    @Parameter(property = "ekstazi.forceall", defaultValue = "false")
-    private boolean forceall;
-
-    /**
      * Additional arguments passed to Ekstazi.
      *
      * @since 4.5.1
@@ -87,11 +70,11 @@ public class StaticSelectEkstaziMojo extends AbstractEkstaziMojo {
     protected String xargs;
 
     public boolean getForcefailing() {
-        return forcefailing;
+        return Config.FORCE_FAILING_V;
     }
 
     public boolean getForceall() {
-        return forceall;
+        return Config.FORCE_ALL_V;
     }
 
     public String getXargs() {

--- a/org.ekstazi.core/src/main/java/org/ekstazi/Config.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/Config.java
@@ -279,6 +279,19 @@ public final class Config {
     }
 
     /**
+     * Pre load configuration from home and user properties.
+     */
+    public static void preLoadConfig() {
+        String userHome = getUserHome();
+        File userHomeDir = new File(userHome, Names.EKSTAZI_CONFIG_FILE);
+        Properties homeProperties = getProperties(userHomeDir);
+        File userDir = new File(System.getProperty("user.dir"), Names.EKSTAZI_CONFIG_FILE);
+        Properties userProperties = getProperties(userDir);
+        loadProperties(homeProperties);
+        loadProperties(userProperties);
+    }
+
+    /**
      * Returns path to user home directory. This method is needed for
      * experiments when we assume that /home/name/ (or similar) is home. Note
      * that projects can override user.home in pom.xml or similar file (e.g.

--- a/org.ekstazi.core/src/main/java/org/ekstazi/agent/AgentLoader.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/agent/AgentLoader.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 
+import org.ekstazi.Config;
 import org.ekstazi.research.Research;
 import org.ekstazi.util.Types;
 
@@ -54,6 +55,7 @@ public final class AgentLoader {
         // initialization multiple times, which would lead to:
         // "libattach.so already loaded in another classloader".
         try {
+            Config.preLoadConfig();
             // Note that this class can be loaded by different classloaders, so
             // we cannot simply use static field to check if the class has been
             // initialized.


### PR DESCRIPTION
### Bug description:
  When using Ekstazi with maven, `force.all` and `force.failing` do not work as expected. To be more specific, if there is no code change, Ekstazi will not rerun tests even if I open `force.all`. The same for `force.failing`, if there is a test failure, Ekstazi will not rerun it if this is set to true.

### Root Cause:
The `forcefailing` and `forceall` in `StaticSelectEkstaziMojo.java` do not get their value from the user's configuration on time. In the current implementation, Ekstazi always tries to use the default value of these configurations because the user's configurations are loaded into Ekstazi too late.

### Fix:
In this PR I deleted the 2 parameters above and directly use `Config.FORCE_FAILING_V` and `Config.FORCE_ALL_V`. 
In `loadEkstaziAgent()` I preload the user's configuration settings in `.ekstazirc` to make sure these 2 configurations are correctly passed into Ekstazi before they got used.

