### PR TITLE
asm: Moving ASM (9_6) to support Java 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ If you have Maven, building Ekstazi is trivial:
 JAVA_TOOL_OPTIONS="-Djdk.attach.allowAttachSelf=true" mvn install
 ```
 
+(`-Djdk.attach.allowAttachSelf=true` is required from Java 11 and
+`-Djava.security.manager=allow` is required from Java 21.)
+
 Building Ekstazi targets Java 8 bytecode specification. The following
 Java versions were used successfully to build Ekstazi code.
 

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/AnnotationVisitor.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/AnnotationVisitor.java
@@ -38,8 +38,8 @@ package org.ekstazi.asm;
 public abstract class AnnotationVisitor {
 
   /**
-   * The ASM API version implemented by this visitor. The value of this field must be one of {@link
-   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+   * The ASM API version implemented by this visitor. The value of this field must be one of the
+   * {@code ASM}<i>x</i> values in {@link Opcodes}.
    */
   protected final int api;
 
@@ -52,22 +52,22 @@ public abstract class AnnotationVisitor {
   /**
    * Constructs a new {@link AnnotationVisitor}.
    *
-   * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+   * @param api the ASM API version implemented by this visitor. Must be one of the {@code
+   *     ASM}<i>x</i> values in {@link Opcodes}.
    */
-  public AnnotationVisitor(final int api) {
+  protected AnnotationVisitor(final int api) {
     this(api, null);
   }
 
   /**
    * Constructs a new {@link AnnotationVisitor}.
    *
-   * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+   * @param api the ASM API version implemented by this visitor. Must be one of the {@code
+   *     ASM}<i>x</i> values in {@link Opcodes}.
    * @param annotationVisitor the annotation visitor to which this visitor must delegate method
    *     calls. May be {@literal null}.
    */
-  public AnnotationVisitor(final int api, final AnnotationVisitor annotationVisitor) {
+  protected AnnotationVisitor(final int api, final AnnotationVisitor annotationVisitor) {
     if (api != Opcodes.ASM9
         && api != Opcodes.ASM8
         && api != Opcodes.ASM7
@@ -82,6 +82,17 @@ public abstract class AnnotationVisitor {
     }
     this.api = api;
     this.av = annotationVisitor;
+  }
+
+  /**
+   * The annotation visitor to which this visitor must delegate method calls. May be {@literal
+   * null}.
+   *
+   * @return the annotation visitor to which this visitor must delegate method calls, or {@literal
+   *     null}.
+   */
+  public AnnotationVisitor getDelegate() {
+    return av;
   }
 
   /**

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/ByteVector.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/ByteVector.java
@@ -66,6 +66,15 @@ public class ByteVector {
   }
 
   /**
+   * Returns the actual number of bytes in this vector.
+   *
+   * @return the actual number of bytes in this vector.
+   */
+  public int size() {
+    return length;
+  }
+
+  /**
    * Puts a byte into this byte vector. The byte vector is automatically enlarged if necessary.
    *
    * @param byteValue a byte.
@@ -352,6 +361,9 @@ public class ByteVector {
    * @param size number of additional bytes that this byte vector should be able to receive.
    */
   private void enlarge(final int size) {
+    if (length > data.length) {
+      throw new AssertionError("Internal error");
+    }
     int doubleCapacity = 2 * data.length;
     int minimalCapacity = length + size;
     byte[] newData = new byte[doubleCapacity > minimalCapacity ? doubleCapacity : minimalCapacity];

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/ClassReader.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/ClassReader.java
@@ -88,6 +88,9 @@ public class ClassReader {
    */
   static final int EXPAND_ASM_INSNS = 256;
 
+  /** The maximum size of array to allocate. */
+  private static final int MAX_BUFFER_SIZE = 1024 * 1024;
+
   /** The size of the temporary byte array used to read class input streams chunk by chunk. */
   private static final int INPUT_STREAM_DATA_CHUNK_SIZE = 4096;
 
@@ -185,13 +188,14 @@ public class ClassReader {
    * @param classFileOffset the offset in byteBuffer of the first byte of the ClassFile to be read.
    * @param checkClassVersion whether to check the class version or not.
    */
+  @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
   ClassReader(
       final byte[] classFileBuffer, final int classFileOffset, final boolean checkClassVersion) {
     this.classFileBuffer = classFileBuffer;
     this.b = classFileBuffer;
     // Check the class' major_version. This field is after the magic and minor_version fields, which
     // use 4 and 2 bytes respectively.
-    if (checkClassVersion && readShort(classFileOffset + 6) > Opcodes.V17) {
+    if (checkClassVersion && readShort(classFileOffset + 6) > Opcodes.V22) {
       throw new IllegalArgumentException(
           "Unsupported class file major version " + readShort(classFileOffset + 6));
     }
@@ -305,24 +309,44 @@ public class ClassReader {
    * @return the content of the given input stream.
    * @throws IOException if a problem occurs during reading.
    */
+  @SuppressWarnings("PMD.UseTryWithResources")
   private static byte[] readStream(final InputStream inputStream, final boolean close)
       throws IOException {
     if (inputStream == null) {
       throw new IOException("Class not found");
     }
+    int bufferSize = computeBufferSize(inputStream);
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-      byte[] data = new byte[INPUT_STREAM_DATA_CHUNK_SIZE];
+      byte[] data = new byte[bufferSize];
       int bytesRead;
-      while ((bytesRead = inputStream.read(data, 0, data.length)) != -1) {
+      int readCount = 0;
+      while ((bytesRead = inputStream.read(data, 0, bufferSize)) != -1) {
         outputStream.write(data, 0, bytesRead);
+        readCount++;
       }
       outputStream.flush();
+      if (readCount == 1) {
+        return data;
+      }
       return outputStream.toByteArray();
     } finally {
       if (close) {
         inputStream.close();
       }
     }
+  }
+
+  private static int computeBufferSize(final InputStream inputStream) throws IOException {
+    int expectedLength = inputStream.available();
+    /*
+     * Some implementations can return 0 while holding available data (e.g. new
+     * FileInputStream("/proc/a_file")). Also in some pathological cases a very small number might
+     * be returned, and in this case we use a default size.
+     */
+    if (expectedLength < 256) {
+      return INPUT_STREAM_DATA_CHUNK_SIZE;
+    }
+    return Math.min(expectedLength, MAX_BUFFER_SIZE);
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -352,7 +376,7 @@ public class ClassReader {
   }
 
   /**
-   * Returns the internal of name of the super class (see {@link Type#getInternalName()}). For
+   * Returns the internal name of the super class (see {@link Type#getInternalName()}). For
    * interfaces, the super class is {@link Object}.
    *
    * @return the internal name of the super class, or {@literal null} for {@link Object} class.
@@ -836,7 +860,7 @@ public class ClassReader {
       currentOffset += 2;
     }
 
-    // Read the  'provides_count' and 'provides' fields.
+    // Read the 'provides_count' and 'provides' fields.
     int providesCount = readUnsignedShort(currentOffset);
     currentOffset += 2;
     while (providesCount-- > 0) {
@@ -2027,6 +2051,7 @@ public class ClassReader {
     currentOffset = bytecodeStartOffset;
     while (currentOffset < bytecodeEndOffset) {
       final int currentBytecodeOffset = currentOffset - bytecodeStartOffset;
+      readBytecodeInstructionOffset(currentBytecodeOffset);
 
       // Visit the label and the line number(s) for this bytecode offset, if any.
       Label currentLabel = labels[currentBytecodeOffset];
@@ -2640,6 +2665,20 @@ public class ClassReader {
 
     // Visit the max stack and max locals values.
     methodVisitor.visitMaxs(maxStack, maxLocals);
+  }
+
+  /**
+   * Handles the bytecode offset of the next instruction to be visited in {@link
+   * #accept(ClassVisitor,int)}. This method is called just before the instruction and before its
+   * associated label and stack map frame, if any. The default implementation of this method does
+   * nothing. Subclasses can override this method to store the argument in a mutable field, for
+   * instance, so that {@link MethodVisitor} instances can get the bytecode offset of each visited
+   * instruction (if so, the usual concurrency issues related to mutable data should be addressed).
+   *
+   * @param bytecodeOffset the bytecode offset of the next instruction to be visited.
+   */
+  protected void readBytecodeInstructionOffset(final int bytecodeOffset) {
+    // Do nothing by default.
   }
 
   /**

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/ClassTooLargeException.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/ClassTooLargeException.java
@@ -42,7 +42,8 @@ public final class ClassTooLargeException extends IndexOutOfBoundsException {
   /**
    * Constructs a new {@link ClassTooLargeException}.
    *
-   * @param className the internal name of the class.
+   * @param className the internal name of the class (see {@link
+   *     org.objectweb.asm.Type#getInternalName()}).
    * @param constantPoolCount the number of constant pool items of the class.
    */
   public ClassTooLargeException(final String className, final int constantPoolCount) {
@@ -52,7 +53,7 @@ public final class ClassTooLargeException extends IndexOutOfBoundsException {
   }
 
   /**
-   * Returns the internal name of the class.
+   * Returns the internal name of the class (see {@link org.objectweb.asm.Type#getInternalName()}).
    *
    * @return the internal name of the class.
    */

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/ClassVisitor.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/ClassVisitor.java
@@ -30,8 +30,8 @@ package org.ekstazi.asm;
 /**
  * A visitor to visit a Java class. The methods of this class must be called in the following order:
  * {@code visit} [ {@code visitSource} ] [ {@code visitModule} ][ {@code visitNestHost} ][ {@code
- * visitPermittedSubclass} ][ {@code visitOuterClass} ] ( {@code visitAnnotation} | {@code
- * visitTypeAnnotation} | {@code visitAttribute} )* ( {@code visitNestMember} | {@code
+ * visitOuterClass} ] ( {@code visitAnnotation} | {@code visitTypeAnnotation} | {@code
+ * visitAttribute} )* ( {@code visitNestMember} | [ {@code * visitPermittedSubclass} ] | {@code
  * visitInnerClass} | {@code visitRecordComponent} | {@code visitField} | {@code visitMethod} )*
  * {@code visitEnd}.
  *
@@ -40,8 +40,8 @@ package org.ekstazi.asm;
 public abstract class ClassVisitor {
 
   /**
-   * The ASM API version implemented by this visitor. The value of this field must be one of {@link
-   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+   * The ASM API version implemented by this visitor. The value of this field must be one of the
+   * {@code ASM}<i>x</i> values in {@link Opcodes}.
    */
   protected final int api;
 
@@ -51,23 +51,22 @@ public abstract class ClassVisitor {
   /**
    * Constructs a new {@link ClassVisitor}.
    *
-   * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+   * @param api the ASM API version implemented by this visitor. Must be one of the {@code
+   *     ASM}<i>x</i> values in {@link Opcodes}.
    */
-  public ClassVisitor(final int api) {
+  protected ClassVisitor(final int api) {
     this(api, null);
   }
 
   /**
    * Constructs a new {@link ClassVisitor}.
    *
-   * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6}, {@link Opcodes#ASM7}, {@link
-   *     Opcodes#ASM8} or {@link Opcodes#ASM9}.
+   * @param api the ASM API version implemented by this visitor. Must be one of the {@code
+   *     ASM}<i>x</i> values in {@link Opcodes}.
    * @param classVisitor the class visitor to which this visitor must delegate method calls. May be
    *     null.
    */
-  public ClassVisitor(final int api, final ClassVisitor classVisitor) {
+  protected ClassVisitor(final int api, final ClassVisitor classVisitor) {
     if (api != Opcodes.ASM9
         && api != Opcodes.ASM8
         && api != Opcodes.ASM7
@@ -82,6 +81,15 @@ public abstract class ClassVisitor {
     }
     this.api = api;
     this.cv = classVisitor;
+  }
+
+  /**
+   * The class visitor to which this visitor must delegate method calls. May be {@literal null}.
+   *
+   * @return the class visitor to which this visitor must delegate method calls, or {@literal null}.
+   */
+  public ClassVisitor getDelegate() {
+    return cv;
   }
 
   /**
@@ -158,7 +166,8 @@ public abstract class ClassVisitor {
    * implicitly its own nest, so it's invalid to call this method with the visited class name as
    * argument.
    *
-   * @param nestHost the internal name of the host class of the nest.
+   * @param nestHost the internal name of the host class of the nest (see {@link
+   *     Type#getInternalName()}).
    */
   public void visitNestHost(final String nestHost) {
     if (api < Opcodes.ASM7) {
@@ -170,14 +179,19 @@ public abstract class ClassVisitor {
   }
 
   /**
-   * Visits the enclosing class of the class. This method must be called only if the class has an
-   * enclosing class.
+   * Visits the enclosing class of the class. This method must be called only if this class is a
+   * local or anonymous class. See the JVMS 4.7.7 section for more details.
    *
-   * @param owner internal name of the enclosing class of the class.
+   * @param owner internal name of the enclosing class of the class (see {@link
+   *     Type#getInternalName()}).
    * @param name the name of the method that contains the class, or {@literal null} if the class is
-   *     not enclosed in a method of its enclosing class.
+   *     not enclosed in a method or constructor of its enclosing class (e.g. if it is enclosed in
+   *     an instance initializer, static initializer, instance variable initializer, or class
+   *     variable initializer).
    * @param descriptor the descriptor of the method that contains the class, or {@literal null} if
-   *     the class is not enclosed in a method of its enclosing class.
+   *     the class is not enclosed in a method or constructor of its enclosing class (e.g. if it is
+   *     enclosed in an instance initializer, static initializer, instance variable initializer, or
+   *     class variable initializer).
    */
   public void visitOuterClass(final String owner, final String name, final String descriptor) {
     if (cv != null) {
@@ -244,7 +258,7 @@ public abstract class ClassVisitor {
    * the visited class is the host of a nest. A nest host is implicitly a member of its own nest, so
    * it's invalid to call this method with the visited class name as argument.
    *
-   * @param nestMember the internal name of a nest member.
+   * @param nestMember the internal name of a nest member (see {@link Type#getInternalName()}).
    */
   public void visitNestMember(final String nestMember) {
     if (api < Opcodes.ASM7) {
@@ -259,7 +273,8 @@ public abstract class ClassVisitor {
    * Visits a permitted subclasses. A permitted subclass is one of the allowed subclasses of the
    * current class.
    *
-   * @param permittedSubclass the internal name of a permitted subclass.
+   * @param permittedSubclass the internal name of a permitted subclass (see {@link
+   *     Type#getInternalName()}).
    */
   public void visitPermittedSubclass(final String permittedSubclass) {
     if (api < Opcodes.ASM9) {
@@ -272,15 +287,18 @@ public abstract class ClassVisitor {
 
   /**
    * Visits information about an inner class. This inner class is not necessarily a member of the
-   * class being visited.
+   * class being visited. More precisely, every class or interface C which is referenced by this
+   * class and which is not a package member must be visited with this method. This class must
+   * reference its nested class or interface members, and its enclosing class, if any. See the JVMS
+   * 4.7.6 section for more details.
    *
-   * @param name the internal name of an inner class (see {@link Type#getInternalName()}).
-   * @param outerName the internal name of the class to which the inner class belongs (see {@link
-   *     Type#getInternalName()}). May be {@literal null} for not member classes.
-   * @param innerName the (simple) name of the inner class inside its enclosing class. May be
-   *     {@literal null} for anonymous inner classes.
-   * @param access the access flags of the inner class as originally declared in the enclosing
-   *     class.
+   * @param name the internal name of C (see {@link Type#getInternalName()}).
+   * @param outerName the internal name of the class or interface C is a member of (see {@link
+   *     Type#getInternalName()}). Must be {@literal null} if C is not the member of a class or
+   *     interface (e.g. for local or anonymous classes).
+   * @param innerName the (simple) name of C. Must be {@literal null} for anonymous inner classes.
+   * @param access the access flags of C originally declared in the source code from which this
+   *     class was compiled.
    */
   public void visitInnerClass(
       final String name, final String outerName, final String innerName, final int access) {

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/ClassWriter.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/ClassWriter.java
@@ -65,6 +65,12 @@ public class ClassWriter extends ClassVisitor {
    */
   public static final int COMPUTE_FRAMES = 2;
 
+  /**
+   * The flags passed to the constructor. Must be zero or more of {@link #COMPUTE_MAXS} and {@link
+   * #COMPUTE_FRAMES}.
+   */
+  private final int flags;
+
   // Note: fields are ordered as in the ClassFile structure, and those related to attributes are
   // ordered as in Section 4.7 of the JVMS.
 
@@ -79,7 +85,7 @@ public class ClassWriter extends ClassVisitor {
 
   /**
    * The access_flags field of the JVMS ClassFile structure. This field can contain ASM specific
-   * access flags, such as {@link Opcodes#ACC_DEPRECATED} or {}@link Opcodes#ACC_RECORD}, which are
+   * access flags, such as {@link Opcodes#ACC_DEPRECATED} or {@link Opcodes#ACC_RECORD}, which are
    * removed when generating the ClassFile structure.
    */
   private int accessFlags;
@@ -211,6 +217,7 @@ public class ClassWriter extends ClassVisitor {
   /**
    * Indicates what must be automatically computed in {@link MethodWriter}. Must be one of {@link
    * MethodWriter#COMPUTE_NOTHING}, {@link MethodWriter#COMPUTE_MAX_STACK_AND_LOCAL}, {@link
+   * MethodWriter#COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES}, {@link
    * MethodWriter#COMPUTE_INSERTED_FRAMES}, or {@link MethodWriter#COMPUTE_ALL_FRAMES}.
    */
   private int compute;
@@ -248,21 +255,37 @@ public class ClassWriter extends ClassVisitor {
    * @param classReader the {@link ClassReader} used to read the original class. It will be used to
    *     copy the entire constant pool and bootstrap methods from the original class and also to
    *     copy other fragments of original bytecode where applicable.
-   * @param flags option flags that can be used to modify the default behavior of this class.Must be
-   *     zero or more of {@link #COMPUTE_MAXS} and {@link #COMPUTE_FRAMES}. <i>These option flags do
-   *     not affect methods that are copied as is in the new class. This means that neither the
+   * @param flags option flags that can be used to modify the default behavior of this class. Must
+   *     be zero or more of {@link #COMPUTE_MAXS} and {@link #COMPUTE_FRAMES}. <i>These option flags
+   *     do not affect methods that are copied as is in the new class. This means that neither the
    *     maximum stack size nor the stack frames will be computed for these methods</i>.
    */
   public ClassWriter(final ClassReader classReader, final int flags) {
     super(/* latest api = */ Opcodes.ASM9);
+    this.flags = flags;
     symbolTable = classReader == null ? new SymbolTable(this) : new SymbolTable(this, classReader);
     if ((flags & COMPUTE_FRAMES) != 0) {
-      this.compute = MethodWriter.COMPUTE_ALL_FRAMES;
+      compute = MethodWriter.COMPUTE_ALL_FRAMES;
     } else if ((flags & COMPUTE_MAXS) != 0) {
-      this.compute = MethodWriter.COMPUTE_MAX_STACK_AND_LOCAL;
+      compute = MethodWriter.COMPUTE_MAX_STACK_AND_LOCAL;
     } else {
-      this.compute = MethodWriter.COMPUTE_NOTHING;
+      compute = MethodWriter.COMPUTE_NOTHING;
     }
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Accessors
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * Returns true if all the given flags were passed to the constructor.
+   *
+   * @param flags some option flags. Must be zero or more of {@link #COMPUTE_MAXS} and {@link
+   *     #COMPUTE_FRAMES}.
+   * @return true if all the given flags, or more, were passed to the constructor.
+   */
+  public boolean hasFlags(final int flags) {
+    return (this.flags & flags) == flags;
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -820,7 +843,7 @@ public class ClassWriter extends ClassVisitor {
    * constant pool already contains a similar item. <i>This method is intended for {@link Attribute}
    * sub classes, and is normally not needed by class generators or adapters.</i>
    *
-   * @param value the internal name of the class.
+   * @param value the internal name of the class (see {@link Type#getInternalName()}).
    * @return the index of a new or already existing class reference item.
    */
   public int newClass(final String value) {
@@ -872,7 +895,8 @@ public class ClassWriter extends ClassVisitor {
    *     Opcodes#H_GETSTATIC}, {@link Opcodes#H_PUTFIELD}, {@link Opcodes#H_PUTSTATIC}, {@link
    *     Opcodes#H_INVOKEVIRTUAL}, {@link Opcodes#H_INVOKESTATIC}, {@link Opcodes#H_INVOKESPECIAL},
    *     {@link Opcodes#H_NEWINVOKESPECIAL} or {@link Opcodes#H_INVOKEINTERFACE}.
-   * @param owner the internal name of the field or method owner class.
+   * @param owner the internal name of the field or method owner class (see {@link
+   *     Type#getInternalName()}).
    * @param name the name of the field or method.
    * @param descriptor the descriptor of the field or method.
    * @return the index of a new or already existing method type reference item.
@@ -894,7 +918,8 @@ public class ClassWriter extends ClassVisitor {
    *     Opcodes#H_GETSTATIC}, {@link Opcodes#H_PUTFIELD}, {@link Opcodes#H_PUTSTATIC}, {@link
    *     Opcodes#H_INVOKEVIRTUAL}, {@link Opcodes#H_INVOKESTATIC}, {@link Opcodes#H_INVOKESPECIAL},
    *     {@link Opcodes#H_NEWINVOKESPECIAL} or {@link Opcodes#H_INVOKEINTERFACE}.
-   * @param owner the internal name of the field or method owner class.
+   * @param owner the internal name of the field or method owner class (see {@link
+   *     Type#getInternalName()}).
    * @param name the name of the field or method.
    * @param descriptor the descriptor of the field or method.
    * @param isInterface true if the owner is an interface.
@@ -956,7 +981,7 @@ public class ClassWriter extends ClassVisitor {
    * constant pool already contains a similar item. <i>This method is intended for {@link Attribute}
    * sub classes, and is normally not needed by class generators or adapters.</i>
    *
-   * @param owner the internal name of the field's owner class.
+   * @param owner the internal name of the field's owner class (see {@link Type#getInternalName()}).
    * @param name the field's name.
    * @param descriptor the field's descriptor.
    * @return the index of a new or already existing field reference item.
@@ -970,7 +995,8 @@ public class ClassWriter extends ClassVisitor {
    * constant pool already contains a similar item. <i>This method is intended for {@link Attribute}
    * sub classes, and is normally not needed by class generators or adapters.</i>
    *
-   * @param owner the internal name of the method's owner class.
+   * @param owner the internal name of the method's owner class (see {@link
+   *     Type#getInternalName()}).
    * @param name the method's name.
    * @param descriptor the method's descriptor.
    * @param isInterface {@literal true} if {@code owner} is an interface.
@@ -1006,9 +1032,10 @@ public class ClassWriter extends ClassVisitor {
    * currently being generated by this ClassWriter, which can of course not be loaded since it is
    * under construction.
    *
-   * @param type1 the internal name of a class.
-   * @param type2 the internal name of another class.
-   * @return the internal name of the common super class of the two given classes.
+   * @param type1 the internal name of a class (see {@link Type#getInternalName()}).
+   * @param type2 the internal name of another class (see {@link Type#getInternalName()}).
+   * @return the internal name of the common super class of the two given classes (see {@link
+   *     Type#getInternalName()}).
    */
   protected String getCommonSuperClass(final String type1, final String type2) {
     ClassLoader classLoader = getClassLoader();

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/FieldVisitor.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/FieldVisitor.java
@@ -37,9 +37,8 @@ package org.ekstazi.asm;
 public abstract class FieldVisitor {
 
   /**
-   * The ASM API version implemented by this visitor. The value of this field must be one of {@link
-   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6}, {@link Opcodes#ASM7}, {@link
-   * Opcodes#ASM8} or {@link Opcodes#ASM9}.
+   * The ASM API version implemented by this visitor. The value of this field must be one of the
+   * {@code ASM}<i>x</i> values in {@link Opcodes}.
    */
   protected final int api;
 
@@ -49,24 +48,22 @@ public abstract class FieldVisitor {
   /**
    * Constructs a new {@link FieldVisitor}.
    *
-   * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6}, {@link Opcodes#ASM7}, {@link
-   *     Opcodes#ASM8} or {@link Opcodes#ASM9}.
+   * @param api the ASM API version implemented by this visitor. Must be one of the {@code
+   *     ASM}<i>x</i> values in {@link Opcodes}.
    */
-  public FieldVisitor(final int api) {
+  protected FieldVisitor(final int api) {
     this(api, null);
   }
 
   /**
    * Constructs a new {@link FieldVisitor}.
    *
-   * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6}, {@link Opcodes#ASM7} or {@link
-   *     Opcodes#ASM8}.
+   * @param api the ASM API version implemented by this visitor. Must be one of the {@code
+   *     ASM}<i>x</i> values in {@link Opcodes}.
    * @param fieldVisitor the field visitor to which this visitor must delegate method calls. May be
    *     null.
    */
-  public FieldVisitor(final int api, final FieldVisitor fieldVisitor) {
+  protected FieldVisitor(final int api, final FieldVisitor fieldVisitor) {
     if (api != Opcodes.ASM9
         && api != Opcodes.ASM8
         && api != Opcodes.ASM7
@@ -81,6 +78,15 @@ public abstract class FieldVisitor {
     }
     this.api = api;
     this.fv = fieldVisitor;
+  }
+
+  /**
+   * The field visitor to which this visitor must delegate method calls. May be {@literal null}.
+   *
+   * @return the field visitor to which this visitor must delegate method calls, or {@literal null}.
+   */
+  public FieldVisitor getDelegate() {
+    return fv;
   }
 
   /**

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/Frame.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/Frame.java
@@ -64,8 +64,8 @@ package org.ekstazi.asm;
  *       right shift of {@link #DIM_SHIFT}.
  *   <li>the KIND field, stored in 4 bits, indicates the kind of VALUE used. These 4 bits can be
  *       retrieved with {@link #KIND_MASK} and, without any shift, must be equal to {@link
- *       #CONSTANT_KIND}, {@link #REFERENCE_KIND}, {@link #UNINITIALIZED_KIND}, {@link #LOCAL_KIND}
- *       or {@link #STACK_KIND}.
+ *       #CONSTANT_KIND}, {@link #REFERENCE_KIND}, {@link #UNINITIALIZED_KIND}, {@link
+ *       #FORWARD_UNINITIALIZED_KIND},{@link #LOCAL_KIND} or {@link #STACK_KIND}.
  *   <li>the FLAGS field, stored in 2 bits, contains up to 2 boolean flags. Currently only one flag
  *       is defined, namely {@link #TOP_IF_LONG_OR_DOUBLE_FLAG}.
  *   <li>the VALUE field, stored in the remaining 20 bits, contains either
@@ -78,7 +78,10 @@ package org.ekstazi.asm;
  *         <li>the index of a {@link Symbol#TYPE_TAG} {@link Symbol} in the type table of a {@link
  *             SymbolTable}, if KIND is equal to {@link #REFERENCE_KIND}.
  *         <li>the index of an {@link Symbol#UNINITIALIZED_TYPE_TAG} {@link Symbol} in the type
- *             table of a SymbolTable, if KIND is equal to {@link #UNINITIALIZED_KIND}.
+ *             table of a {@link SymbolTable}, if KIND is equal to {@link #UNINITIALIZED_KIND}.
+ *         <li>the index of a {@link Symbol#FORWARD_UNINITIALIZED_TYPE_TAG} {@link Symbol} in the
+ *             type table of a {@link SymbolTable}, if KIND is equal to {@link
+ *             #FORWARD_UNINITIALIZED_KIND}.
  *         <li>the index of a local variable in the input stack frame, if KIND is equal to {@link
  *             #LOCAL_KIND}.
  *         <li>a position relatively to the top of the stack of the input stack frame, if KIND is
@@ -88,10 +91,10 @@ package org.ekstazi.asm;
  *
  * <p>Output frames can contain abstract types of any kind and with a positive or negative array
  * dimension (and even unassigned types, represented by 0 - which does not correspond to any valid
- * abstract type value). Input frames can only contain CONSTANT_KIND, REFERENCE_KIND or
- * UNINITIALIZED_KIND abstract types of positive or {@literal null} array dimension. In all cases
- * the type table contains only internal type names (array type descriptors are forbidden - array
- * dimensions must be represented through the DIM field).
+ * abstract type value). Input frames can only contain CONSTANT_KIND, REFERENCE_KIND,
+ * UNINITIALIZED_KIND or FORWARD_UNINITIALIZED_KIND abstract types of positive or {@literal null}
+ * array dimension. In all cases the type table contains only internal type names (array type
+ * descriptors are forbidden - array dimensions must be represented through the DIM field).
  *
  * <p>The LONG and DOUBLE types are always represented by using two slots (LONG + TOP or DOUBLE +
  * TOP), for local variables as well as in the operand stack. This is necessary to be able to
@@ -159,8 +162,9 @@ class Frame {
   private static final int CONSTANT_KIND = 1 << KIND_SHIFT;
   private static final int REFERENCE_KIND = 2 << KIND_SHIFT;
   private static final int UNINITIALIZED_KIND = 3 << KIND_SHIFT;
-  private static final int LOCAL_KIND = 4 << KIND_SHIFT;
-  private static final int STACK_KIND = 5 << KIND_SHIFT;
+  private static final int FORWARD_UNINITIALIZED_KIND = 4 << KIND_SHIFT;
+  private static final int LOCAL_KIND = 5 << KIND_SHIFT;
+  private static final int STACK_KIND = 6 << KIND_SHIFT;
 
   // Possible flags for the FLAGS field of an abstract type.
 
@@ -220,13 +224,13 @@ class Frame {
 
   /**
    * The abstract types that are initialized in the basic block. A constructor invocation on an
-   * UNINITIALIZED or UNINITIALIZED_THIS abstract type must replace <i>every occurrence</i> of this
-   * type in the local variables and in the operand stack. This cannot be done during the first step
-   * of the algorithm since, during this step, the local variables and the operand stack types are
-   * still abstract. It is therefore necessary to store the abstract types of the constructors which
-   * are invoked in the basic block, in order to do this replacement during the second step of the
-   * algorithm, where the frames are fully computed. Note that this array can contain abstract types
-   * that are relative to the input locals or to the input stack.
+   * UNINITIALIZED, FORWARD_UNINITIALIZED or UNINITIALIZED_THIS abstract type must replace <i>every
+   * occurrence</i> of this type in the local variables and in the operand stack. This cannot be
+   * done during the first step of the algorithm since, during this step, the local variables and
+   * the operand stack types are still abstract. It is therefore necessary to store the abstract
+   * types of the constructors which are invoked in the basic block, in order to do this replacement
+   * during the second step of the algorithm, where the frames are fully computed. Note that this
+   * array can contain abstract types that are relative to the input locals or to the input stack.
    */
   private int[] initializations;
 
@@ -284,8 +288,12 @@ class Frame {
       String descriptor = Type.getObjectType((String) type).getDescriptor();
       return getAbstractTypeFromDescriptor(symbolTable, descriptor, 0);
     } else {
-      return UNINITIALIZED_KIND
-          | symbolTable.addUninitializedType("", ((Label) type).bytecodeOffset);
+      Label label = (Label) type;
+      if ((label.flags & Label.FLAG_RESOLVED) != 0) {
+        return UNINITIALIZED_KIND | symbolTable.addUninitializedType("", label.bytecodeOffset);
+      } else {
+        return FORWARD_UNINITIALIZED_KIND | symbolTable.addForwardUninitializedType("", label);
+      }
     }
   }
 
@@ -367,11 +375,12 @@ class Frame {
             typeValue = REFERENCE_KIND | symbolTable.addType(internalName);
             break;
           default:
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(
+                "Invalid descriptor fragment: " + buffer.substring(elementDescriptorOffset));
         }
         return ((elementDescriptorOffset - offset) << DIM_SHIFT) | typeValue;
       default:
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("Invalid descriptor: " + buffer.substring(offset));
     }
   }
 
@@ -636,12 +645,14 @@ class Frame {
    * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
    * @param abstractType an abstract type.
    * @return the REFERENCE_KIND abstract type corresponding to abstractType if it is
-   *     UNINITIALIZED_THIS or an UNINITIALIZED_KIND abstract type for one of the types on which a
-   *     constructor is invoked in the basic block. Otherwise returns abstractType.
+   *     UNINITIALIZED_THIS or an UNINITIALIZED_KIND or FORWARD_UNINITIALIZED_KIND abstract type for
+   *     one of the types on which a constructor is invoked in the basic block. Otherwise returns
+   *     abstractType.
    */
   private int getInitializedType(final SymbolTable symbolTable, final int abstractType) {
     if (abstractType == UNINITIALIZED_THIS
-        || (abstractType & (DIM_MASK | KIND_MASK)) == UNINITIALIZED_KIND) {
+        || (abstractType & (DIM_MASK | KIND_MASK)) == UNINITIALIZED_KIND
+        || (abstractType & (DIM_MASK | KIND_MASK)) == FORWARD_UNINITIALIZED_KIND) {
       for (int i = 0; i < initializationCount; ++i) {
         int initializedType = initializations[i];
         int dim = initializedType & DIM_MASK;
@@ -1252,11 +1263,12 @@ class Frame {
    *
    * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
    * @param sourceType the abstract type with which the abstract type array element must be merged.
-   *     This type should be of {@link #CONSTANT_KIND}, {@link #REFERENCE_KIND} or {@link
-   *     #UNINITIALIZED_KIND} kind, with positive or {@literal null} array dimensions.
+   *     This type should be of {@link #CONSTANT_KIND}, {@link #REFERENCE_KIND}, {@link
+   *     #UNINITIALIZED_KIND} or {@link #FORWARD_UNINITIALIZED_KIND} kind, with positive or
+   *     {@literal null} array dimensions.
    * @param dstTypes an array of abstract types. These types should be of {@link #CONSTANT_KIND},
-   *     {@link #REFERENCE_KIND} or {@link #UNINITIALIZED_KIND} kind, with positive or {@literal
-   *     null} array dimensions.
+   *     {@link #REFERENCE_KIND}, {@link #UNINITIALIZED_KIND} or {@link #FORWARD_UNINITIALIZED_KIND}
+   *     kind, with positive or {@literal null} array dimensions.
    * @param dstIndex the index of the type that must be merged in dstTypes.
    * @return {@literal true} if the type array has been modified by this operation.
    */
@@ -1399,7 +1411,8 @@ class Frame {
    *
    * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
    * @param abstractType an abstract type, restricted to {@link Frame#CONSTANT_KIND}, {@link
-   *     Frame#REFERENCE_KIND} or {@link Frame#UNINITIALIZED_KIND} types.
+   *     Frame#REFERENCE_KIND}, {@link Frame#UNINITIALIZED_KIND} or {@link
+   *     Frame#FORWARD_UNINITIALIZED_KIND} types.
    * @param output where the abstract type must be put.
    * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.4">JVMS
    *     4.7.4</a>
@@ -1420,6 +1433,10 @@ class Frame {
           break;
         case UNINITIALIZED_KIND:
           output.putByte(ITEM_UNINITIALIZED).putShort((int) symbolTable.getType(typeValue).data);
+          break;
+        case FORWARD_UNINITIALIZED_KIND:
+          output.putByte(ITEM_UNINITIALIZED);
+          symbolTable.getForwardUninitializedLabel(typeValue).put(output);
           break;
         default:
           throw new AssertionError();

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/Handle.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/Handle.java
@@ -65,7 +65,7 @@ public final class Handle {
    *     {@link Opcodes#H_INVOKESPECIAL}, {@link Opcodes#H_NEWINVOKESPECIAL} or {@link
    *     Opcodes#H_INVOKEINTERFACE}.
    * @param owner the internal name of the class that owns the field or method designated by this
-   *     handle.
+   *     handle (see {@link Type#getInternalName()}).
    * @param name the name of the field or method designated by this handle.
    * @param descriptor the descriptor of the field or method designated by this handle.
    * @deprecated this constructor has been superseded by {@link #Handle(int, String, String, String,
@@ -85,7 +85,7 @@ public final class Handle {
    *     {@link Opcodes#H_INVOKESPECIAL}, {@link Opcodes#H_NEWINVOKESPECIAL} or {@link
    *     Opcodes#H_INVOKEINTERFACE}.
    * @param owner the internal name of the class that owns the field or method designated by this
-   *     handle.
+   *     handle (see {@link Type#getInternalName()}).
    * @param name the name of the field or method designated by this handle.
    * @param descriptor the descriptor of the field or method designated by this handle.
    * @param isInterface whether the owner is an interface or not.
@@ -118,7 +118,8 @@ public final class Handle {
   /**
    * Returns the internal name of the class that owns the field or method designated by this handle.
    *
-   * @return the internal name of the class that owns the field or method designated by this handle.
+   * @return the internal name of the class that owns the field or method designated by this handle
+   *     (see {@link Type#getInternalName()}).
    */
   public String getOwner() {
     return owner;

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/Label.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/Label.java
@@ -81,6 +81,9 @@ public class Label {
   /** A flag indicating that the basic block corresponding to a label is the end of a subroutine. */
   static final int FLAG_SUBROUTINE_END = 64;
 
+  /** A flag indicating that this label has at least one associated line number. */
+  static final int FLAG_LINE_NUMBER = 128;
+
   /**
    * The number of elements to add to the {@link #otherLineNumbers} array when it needs to be
    * resized to store a new source line number.
@@ -114,6 +117,13 @@ public class Label {
   static final int FORWARD_REFERENCE_TYPE_WIDE = 0x20000000;
 
   /**
+   * The type of forward references stored in two bytes in the <i>stack map table</i>. This is the
+   * case of the labels of {@link Frame#ITEM_UNINITIALIZED} stack map frame elements, when the NEW
+   * instruction is after the &lt;init&gt; constructor call (in bytecode offset order).
+   */
+  static final int FORWARD_REFERENCE_TYPE_STACK_MAP = 0x30000000;
+
+  /**
    * The bit mask to extract the 'handle' of a forward reference to this label. The extracted handle
    * is the bytecode offset where the forward reference value is stored (using either 2 or 4 bytes,
    * as indicated by the {@link #FORWARD_REFERENCE_TYPE_MASK}).
@@ -145,9 +155,9 @@ public class Label {
   short flags;
 
   /**
-   * The source line number corresponding to this label, or 0. If there are several source line
-   * numbers corresponding to this label, the first one is stored in this field, and the remaining
-   * ones are stored in {@link #otherLineNumbers}.
+   * The source line number corresponding to this label, if {@link #FLAG_LINE_NUMBER} is set. If
+   * there are several source line numbers corresponding to this label, the first one is stored in
+   * this field, and the remaining ones are stored in {@link #otherLineNumbers}.
    */
   private short lineNumber;
 
@@ -332,7 +342,8 @@ public class Label {
    * @param lineNumber a source line number (which should be strictly positive).
    */
   final void addLineNumber(final int lineNumber) {
-    if (this.lineNumber == 0) {
+    if ((flags & FLAG_LINE_NUMBER) == 0) {
+      flags |= FLAG_LINE_NUMBER;
       this.lineNumber = (short) lineNumber;
     } else {
       if (otherLineNumbers == null) {
@@ -356,7 +367,7 @@ public class Label {
    */
   final void accept(final MethodVisitor methodVisitor, final boolean visitLineNumbers) {
     methodVisitor.visitLabel(this);
-    if (visitLineNumbers && lineNumber != 0) {
+    if (visitLineNumbers && (flags & FLAG_LINE_NUMBER) != 0) {
       methodVisitor.visitLineNumber(lineNumber & 0xFFFF, this);
       if (otherLineNumbers != null) {
         for (int i = 1; i <= otherLineNumbers[0]; ++i) {
@@ -401,6 +412,20 @@ public class Label {
   }
 
   /**
+   * Puts a reference to this label in the <i>stack map table</i> of a method. If the bytecode
+   * offset of the label is known, it is written directly. Otherwise, a null relative offset is
+   * written and a new forward reference is declared for this label.
+   *
+   * @param stackMapTableEntries the stack map table where the label offset must be added.
+   */
+  final void put(final ByteVector stackMapTableEntries) {
+    if ((flags & FLAG_RESOLVED) == 0) {
+      addForwardReference(0, FORWARD_REFERENCE_TYPE_STACK_MAP, stackMapTableEntries.length);
+    }
+    stackMapTableEntries.putShort(bytecodeOffset);
+  }
+
+  /**
    * Adds a forward reference to this label. This method must be called only for a true forward
    * reference, i.e. only if this label is not resolved yet. For backward references, the relative
    * bytecode offset of the reference can be, and must be, computed and stored directly.
@@ -432,9 +457,12 @@ public class Label {
    * Sets the bytecode offset of this label to the given value and resolves the forward references
    * to this label, if any. This method must be called when this label is added to the bytecode of
    * the method, i.e. when its bytecode offset becomes known. This method fills in the blanks that
-   * where left in the bytecode by each forward reference previously added to this label.
+   * where left in the bytecode (and optionally in the stack map table) by each forward reference
+   * previously added to this label.
    *
    * @param code the bytecode of the method.
+   * @param stackMapTableEntries the 'entries' array of the StackMapTable code attribute of the
+   *     method. Maybe {@literal null}.
    * @param bytecodeOffset the bytecode offset of this label.
    * @return {@literal true} if a blank that was left for this label was too small to store the
    *     offset. In such a case the corresponding jump instruction is replaced with an equivalent
@@ -442,7 +470,8 @@ public class Label {
    *     instructions are later replaced with standard bytecode instructions with wider offsets (4
    *     bytes instead of 2), in ClassReader.
    */
-  final boolean resolve(final byte[] code, final int bytecodeOffset) {
+  final boolean resolve(
+      final byte[] code, final ByteVector stackMapTableEntries, final int bytecodeOffset) {
     this.flags |= FLAG_RESOLVED;
     this.bytecodeOffset = bytecodeOffset;
     if (forwardReferences == null) {
@@ -472,11 +501,14 @@ public class Label {
         }
         code[handle++] = (byte) (relativeOffset >>> 8);
         code[handle] = (byte) relativeOffset;
-      } else {
+      } else if ((reference & FORWARD_REFERENCE_TYPE_MASK) == FORWARD_REFERENCE_TYPE_WIDE) {
         code[handle++] = (byte) (relativeOffset >>> 24);
         code[handle++] = (byte) (relativeOffset >>> 16);
         code[handle++] = (byte) (relativeOffset >>> 8);
         code[handle] = (byte) relativeOffset;
+      } else {
+        stackMapTableEntries.data[handle++] = (byte) (bytecodeOffset >>> 8);
+        stackMapTableEntries.data[handle] = (byte) bytecodeOffset;
       }
     }
     return hasAsmInstructions;

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/MethodTooLargeException.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/MethodTooLargeException.java
@@ -44,7 +44,7 @@ public final class MethodTooLargeException extends IndexOutOfBoundsException {
   /**
    * Constructs a new {@link MethodTooLargeException}.
    *
-   * @param className the internal name of the owner class.
+   * @param className the internal name of the owner class (see {@link Type#getInternalName()}).
    * @param methodName the name of the method.
    * @param descriptor the descriptor of the method.
    * @param codeSize the size of the method's Code attribute, in bytes.
@@ -64,7 +64,7 @@ public final class MethodTooLargeException extends IndexOutOfBoundsException {
   /**
    * Returns the internal name of the owner class.
    *
-   * @return the internal name of the owner class.
+   * @return the internal name of the owner class (see {@link Type#getInternalName()}).
    */
   public String getClassName() {
     return className;

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/MethodVisitor.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/MethodVisitor.java
@@ -30,7 +30,7 @@ package org.ekstazi.asm;
 /**
  * A visitor to visit a Java method. The methods of this class must be called in the following
  * order: ( {@code visitParameter} )* [ {@code visitAnnotationDefault} ] ( {@code visitAnnotation} |
- * {@code visitAnnotableParameterCount} | {@code visitParameterAnnotation} {@code
+ * {@code visitAnnotableParameterCount} | {@code visitParameterAnnotation} | {@code
  * visitTypeAnnotation} | {@code visitAttribute} )* [ {@code visitCode} ( {@code visitFrame} |
  * {@code visit<i>X</i>Insn} | {@code visitLabel} | {@code visitInsnAnnotation} | {@code
  * visitTryCatchBlock} | {@code visitTryCatchAnnotation} | {@code visitLocalVariable} | {@code
@@ -51,8 +51,8 @@ public abstract class MethodVisitor {
   private static final String REQUIRES_ASM5 = "This feature requires ASM5";
 
   /**
-   * The ASM API version implemented by this visitor. The value of this field must be one of {@link
-   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+   * The ASM API version implemented by this visitor. The value of this field must be one of the
+   * {@code ASM}<i>x</i> values in {@link Opcodes}.
    */
   protected final int api;
 
@@ -64,22 +64,22 @@ public abstract class MethodVisitor {
   /**
    * Constructs a new {@link MethodVisitor}.
    *
-   * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+   * @param api the ASM API version implemented by this visitor. Must be one of the {@code
+   *     ASM}<i>x</i> values in {@link Opcodes}.
    */
-  public MethodVisitor(final int api) {
+  protected MethodVisitor(final int api) {
     this(api, null);
   }
 
   /**
    * Constructs a new {@link MethodVisitor}.
    *
-   * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+   * @param api the ASM API version implemented by this visitor. Must be one of the {@code
+   *     ASM}<i>x</i> values in {@link Opcodes}.
    * @param methodVisitor the method visitor to which this visitor must delegate method calls. May
    *     be null.
    */
-  public MethodVisitor(final int api, final MethodVisitor methodVisitor) {
+  protected MethodVisitor(final int api, final MethodVisitor methodVisitor) {
     if (api != Opcodes.ASM9
         && api != Opcodes.ASM8
         && api != Opcodes.ASM7
@@ -94,6 +94,16 @@ public abstract class MethodVisitor {
     }
     this.api = api;
     this.mv = methodVisitor;
+  }
+
+  /**
+   * The method visitor to which this visitor must delegate method calls. May be {@literal null}.
+   *
+   * @return the method visitor to which this visitor must delegate method calls, or {@literal
+   *     null}.
+   */
+  public MethodVisitor getDelegate() {
+    return mv;
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -122,7 +132,7 @@ public abstract class MethodVisitor {
    * @return a visitor to the visit the actual default value of this annotation interface method, or
    *     {@literal null} if this visitor is not interested in visiting this default value. The
    *     'name' parameters passed to the methods of this annotation visitor are ignored. Moreover,
-   *     exacly one visit method must be called on this annotation visitor, followed by visitEnd.
+   *     exactly one visit method must be called on this annotation visitor, followed by visitEnd.
    */
   public AnnotationVisitor visitAnnotationDefault() {
     if (mv != null) {
@@ -275,15 +285,17 @@ public abstract class MethodVisitor {
    * @param type the type of this stack map frame. Must be {@link Opcodes#F_NEW} for expanded
    *     frames, or {@link Opcodes#F_FULL}, {@link Opcodes#F_APPEND}, {@link Opcodes#F_CHOP}, {@link
    *     Opcodes#F_SAME} or {@link Opcodes#F_APPEND}, {@link Opcodes#F_SAME1} for compressed frames.
-   * @param numLocal the number of local variables in the visited frame.
+   * @param numLocal the number of local variables in the visited frame. Long and double values
+   *     count for one variable.
    * @param local the local variable types in this frame. This array must not be modified. Primitive
    *     types are represented by {@link Opcodes#TOP}, {@link Opcodes#INTEGER}, {@link
    *     Opcodes#FLOAT}, {@link Opcodes#LONG}, {@link Opcodes#DOUBLE}, {@link Opcodes#NULL} or
    *     {@link Opcodes#UNINITIALIZED_THIS} (long and double are represented by a single element).
-   *     Reference types are represented by String objects (representing internal names), and
-   *     uninitialized types by Label objects (this label designates the NEW instruction that
-   *     created this uninitialized value).
-   * @param numStack the number of operand stack elements in the visited frame.
+   *     Reference types are represented by String objects (representing internal names, see {@link
+   *     Type#getInternalName()}), and uninitialized types by Label objects (this label designates
+   *     the NEW instruction that created this uninitialized value).
+   * @param numStack the number of operand stack elements in the visited frame. Long and double
+   *     values count for one stack element.
    * @param stack the operand stack types in this frame. This array must not be modified. Its
    *     content has the same format as the "local" array.
    * @throws IllegalStateException if a frame is visited just after another one, without any
@@ -351,18 +363,18 @@ public abstract class MethodVisitor {
    *
    * @param opcode the opcode of the local variable instruction to be visited. This opcode is either
    *     ILOAD, LLOAD, FLOAD, DLOAD, ALOAD, ISTORE, LSTORE, FSTORE, DSTORE, ASTORE or RET.
-   * @param var the operand of the instruction to be visited. This operand is the index of a local
-   *     variable.
+   * @param varIndex the operand of the instruction to be visited. This operand is the index of a
+   *     local variable.
    */
-  public void visitVarInsn(final int opcode, final int var) {
+  public void visitVarInsn(final int opcode, final int varIndex) {
     if (mv != null) {
-      mv.visitVarInsn(opcode, var);
+      mv.visitVarInsn(opcode, varIndex);
     }
   }
 
   /**
    * Visits a type instruction. A type instruction is an instruction that takes the internal name of
-   * a class as parameter.
+   * a class as parameter (see {@link Type#getInternalName()}).
    *
    * @param opcode the opcode of the type instruction to be visited. This opcode is either NEW,
    *     ANEWARRAY, CHECKCAST or INSTANCEOF.
@@ -554,12 +566,12 @@ public abstract class MethodVisitor {
   /**
    * Visits an IINC instruction.
    *
-   * @param var index of the local variable to be incremented.
+   * @param varIndex index of the local variable to be incremented.
    * @param increment amount to increment the local variable by.
    */
-  public void visitIincInsn(final int var, final int increment) {
+  public void visitIincInsn(final int varIndex, final int increment) {
     if (mv != null) {
-      mv.visitIincInsn(var, increment);
+      mv.visitIincInsn(varIndex, increment);
     }
   }
 
@@ -645,8 +657,9 @@ public abstract class MethodVisitor {
    * @param start the beginning of the exception handler's scope (inclusive).
    * @param end the end of the exception handler's scope (exclusive).
    * @param handler the beginning of the exception handler's code.
-   * @param type the internal name of the type of exceptions handled by the handler, or {@literal
-   *     null} to catch any exceptions (for "finally" blocks).
+   * @param type the internal name of the type of exceptions handled by the handler (see {@link
+   *     Type#getInternalName()}), or {@literal null} to catch any exceptions (for "finally"
+   *     blocks).
    * @throws IllegalArgumentException if one of the labels has already been visited by this visitor
    *     (by the {@link #visitLabel} method).
    */

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/MethodWriter.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/MethodWriter.java
@@ -466,7 +466,8 @@ final class MethodWriter extends MethodVisitor {
 
   /**
    * Indicates what must be computed. Must be one of {@link #COMPUTE_ALL_FRAMES}, {@link
-   * #COMPUTE_INSERTED_FRAMES}, {@link #COMPUTE_MAX_STACK_AND_LOCAL} or {@link #COMPUTE_NOTHING}.
+   * #COMPUTE_INSERTED_FRAMES}, {@link COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES}, {@link
+   * #COMPUTE_MAX_STACK_AND_LOCAL} or {@link #COMPUTE_NOTHING}.
    */
   private final int compute;
 
@@ -533,8 +534,9 @@ final class MethodWriter extends MethodVisitor {
    * the number of stack elements. The local variables start at index 3 and are followed by the
    * operand stack elements. In summary frame[0] = offset, frame[1] = numLocal, frame[2] = numStack.
    * Local variables and operand stack entries contain abstract types, as defined in {@link Frame},
-   * but restricted to {@link Frame#CONSTANT_KIND}, {@link Frame#REFERENCE_KIND} or {@link
-   * Frame#UNINITIALIZED_KIND} abstract types. Long and double types use only one array entry.
+   * but restricted to {@link Frame#CONSTANT_KIND}, {@link Frame#REFERENCE_KIND}, {@link
+   * Frame#UNINITIALIZED_KIND} or {@link Frame#FORWARD_UNINITIALIZED_KIND} abstract types. Long and
+   * double types use only one array entry.
    */
   private int[] currentFrame;
 
@@ -692,7 +694,7 @@ final class MethodWriter extends MethodVisitor {
     if (visible) {
       if (lastRuntimeVisibleParameterAnnotations == null) {
         lastRuntimeVisibleParameterAnnotations =
-            new AnnotationWriter[Type.getArgumentTypes(descriptor).length];
+            new AnnotationWriter[Type.getArgumentCount(descriptor)];
       }
       return lastRuntimeVisibleParameterAnnotations[parameter] =
           AnnotationWriter.create(
@@ -700,7 +702,7 @@ final class MethodWriter extends MethodVisitor {
     } else {
       if (lastRuntimeInvisibleParameterAnnotations == null) {
         lastRuntimeInvisibleParameterAnnotations =
-            new AnnotationWriter[Type.getArgumentTypes(descriptor).length];
+            new AnnotationWriter[Type.getArgumentCount(descriptor)];
       }
       return lastRuntimeInvisibleParameterAnnotations[parameter] =
           AnnotationWriter.create(
@@ -904,26 +906,26 @@ final class MethodWriter extends MethodVisitor {
   }
 
   @Override
-  public void visitVarInsn(final int opcode, final int var) {
+  public void visitVarInsn(final int opcode, final int varIndex) {
     lastBytecodeOffset = code.length;
     // Add the instruction to the bytecode of the method.
-    if (var < 4 && opcode != Opcodes.RET) {
+    if (varIndex < 4 && opcode != Opcodes.RET) {
       int optimizedOpcode;
       if (opcode < Opcodes.ISTORE) {
-        optimizedOpcode = Constants.ILOAD_0 + ((opcode - Opcodes.ILOAD) << 2) + var;
+        optimizedOpcode = Constants.ILOAD_0 + ((opcode - Opcodes.ILOAD) << 2) + varIndex;
       } else {
-        optimizedOpcode = Constants.ISTORE_0 + ((opcode - Opcodes.ISTORE) << 2) + var;
+        optimizedOpcode = Constants.ISTORE_0 + ((opcode - Opcodes.ISTORE) << 2) + varIndex;
       }
       code.putByte(optimizedOpcode);
-    } else if (var >= 256) {
-      code.putByte(Constants.WIDE).put12(opcode, var);
+    } else if (varIndex >= 256) {
+      code.putByte(Constants.WIDE).put12(opcode, varIndex);
     } else {
-      code.put11(opcode, var);
+      code.put11(opcode, varIndex);
     }
     // If needed, update the maximum stack size and number of locals, and stack map frames.
     if (currentBasicBlock != null) {
       if (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES) {
-        currentBasicBlock.frame.execute(opcode, var, null, null);
+        currentBasicBlock.frame.execute(opcode, varIndex, null, null);
       } else {
         if (opcode == Opcodes.RET) {
           // No stack size delta.
@@ -945,9 +947,9 @@ final class MethodWriter extends MethodVisitor {
           || opcode == Opcodes.DLOAD
           || opcode == Opcodes.LSTORE
           || opcode == Opcodes.DSTORE) {
-        currentMaxLocals = var + 2;
+        currentMaxLocals = varIndex + 2;
       } else {
-        currentMaxLocals = var + 1;
+        currentMaxLocals = varIndex + 1;
       }
       if (currentMaxLocals > maxLocals) {
         maxLocals = currentMaxLocals;
@@ -1198,7 +1200,7 @@ final class MethodWriter extends MethodVisitor {
   @Override
   public void visitLabel(final Label label) {
     // Resolve the forward references to this label, if any.
-    hasAsmInstructions |= label.resolve(code.data, code.length);
+    hasAsmInstructions |= label.resolve(code.data, stackMapTableEntries, code.length);
     // visitLabel starts a new basic block (except for debug only labels), so we need to update the
     // previous and current block references and list of successors.
     if ((label.flags & Label.FLAG_DEBUG_ONLY) != 0) {
@@ -1307,21 +1309,21 @@ final class MethodWriter extends MethodVisitor {
   }
 
   @Override
-  public void visitIincInsn(final int var, final int increment) {
+  public void visitIincInsn(final int varIndex, final int increment) {
     lastBytecodeOffset = code.length;
     // Add the instruction to the bytecode of the method.
-    if ((var > 255) || (increment > 127) || (increment < -128)) {
-      code.putByte(Constants.WIDE).put12(Opcodes.IINC, var).putShort(increment);
+    if ((varIndex > 255) || (increment > 127) || (increment < -128)) {
+      code.putByte(Constants.WIDE).put12(Opcodes.IINC, varIndex).putShort(increment);
     } else {
-      code.putByte(Opcodes.IINC).put11(var, increment);
+      code.putByte(Opcodes.IINC).put11(varIndex, increment);
     }
     // If needed, update the maximum stack size and number of locals, and stack map frames.
     if (currentBasicBlock != null
         && (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES)) {
-      currentBasicBlock.frame.execute(Opcodes.IINC, var, null, null);
+      currentBasicBlock.frame.execute(Opcodes.IINC, varIndex, null, null);
     }
     if (compute != COMPUTE_NOTHING) {
-      int currentMaxLocals = var + 1;
+      int currentMaxLocals = varIndex + 1;
       if (currentMaxLocals > maxLocals) {
         maxLocals = currentMaxLocals;
       }
@@ -1794,7 +1796,7 @@ final class MethodWriter extends MethodVisitor {
     if (compute == COMPUTE_ALL_FRAMES) {
       Label nextBasicBlock = new Label();
       nextBasicBlock.frame = new Frame(nextBasicBlock);
-      nextBasicBlock.resolve(code.data, code.length);
+      nextBasicBlock.resolve(code.data, stackMapTableEntries, code.length);
       lastBasicBlock.nextBasicBlock = nextBasicBlock;
       lastBasicBlock = nextBasicBlock;
       currentBasicBlock = null;
@@ -1978,9 +1980,8 @@ final class MethodWriter extends MethodVisitor {
           .putByte(Frame.ITEM_OBJECT)
           .putShort(symbolTable.addConstantClass((String) type).index);
     } else {
-      stackMapTableEntries
-          .putByte(Frame.ITEM_UNINITIALIZED)
-          .putShort(((Label) type).bytecodeOffset);
+      stackMapTableEntries.putByte(Frame.ITEM_UNINITIALIZED);
+      ((Label) type).put(stackMapTableEntries);
     }
   }
 

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/ModuleVisitor.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/ModuleVisitor.java
@@ -53,7 +53,7 @@ public abstract class ModuleVisitor {
    * @param api the ASM API version implemented by this visitor. Must be one of {@link Opcodes#ASM6}
    *     or {@link Opcodes#ASM7}.
    */
-  public ModuleVisitor(final int api) {
+  protected ModuleVisitor(final int api) {
     this(api, null);
   }
 
@@ -65,7 +65,7 @@ public abstract class ModuleVisitor {
    * @param moduleVisitor the module visitor to which this visitor must delegate method calls. May
    *     be null.
    */
-  public ModuleVisitor(final int api, final ModuleVisitor moduleVisitor) {
+  protected ModuleVisitor(final int api, final ModuleVisitor moduleVisitor) {
     if (api != Opcodes.ASM9
         && api != Opcodes.ASM8
         && api != Opcodes.ASM7
@@ -83,9 +83,20 @@ public abstract class ModuleVisitor {
   }
 
   /**
+   * The module visitor to which this visitor must delegate method calls. May be {@literal null}.
+   *
+   * @return the module visitor to which this visitor must delegate method calls, or {@literal
+   *     null}.
+   */
+  public ModuleVisitor getDelegate() {
+    return mv;
+  }
+
+  /**
    * Visit the main class of the current module.
    *
-   * @param mainClass the internal name of the main class of the current module.
+   * @param mainClass the internal name of the main class of the current module (see {@link
+   *     Type#getInternalName()}).
    */
   public void visitMainClass(final String mainClass) {
     if (mv != null) {
@@ -96,7 +107,7 @@ public abstract class ModuleVisitor {
   /**
    * Visit a package of the current module.
    *
-   * @param packaze the internal name of a package.
+   * @param packaze the internal name of a package (see {@link Type#getInternalName()}).
    */
   public void visitPackage(final String packaze) {
     if (mv != null) {
@@ -121,7 +132,7 @@ public abstract class ModuleVisitor {
   /**
    * Visit an exported package of the current module.
    *
-   * @param packaze the internal name of the exported package.
+   * @param packaze the internal name of the exported package (see {@link Type#getInternalName()}).
    * @param access the access flag of the exported package, valid values are among {@code
    *     ACC_SYNTHETIC} and {@code ACC_MANDATED}.
    * @param modules the fully qualified names (using dots) of the modules that can access the public
@@ -136,7 +147,7 @@ public abstract class ModuleVisitor {
   /**
    * Visit an open package of the current module.
    *
-   * @param packaze the internal name of the opened package.
+   * @param packaze the internal name of the opened package (see {@link Type#getInternalName()}).
    * @param access the access flag of the opened package, valid values are among {@code
    *     ACC_SYNTHETIC} and {@code ACC_MANDATED}.
    * @param modules the fully qualified names (using dots) of the modules that can use deep
@@ -152,7 +163,7 @@ public abstract class ModuleVisitor {
    * Visit a service used by the current module. The name must be the internal name of an interface
    * or a class.
    *
-   * @param service the internal name of the service.
+   * @param service the internal name of the service (see {@link Type#getInternalName()}).
    */
   public void visitUse(final String service) {
     if (mv != null) {
@@ -163,9 +174,9 @@ public abstract class ModuleVisitor {
   /**
    * Visit an implementation of a service.
    *
-   * @param service the internal name of the service.
-   * @param providers the internal names of the implementations of the service (there is at least
-   *     one provider).
+   * @param service the internal name of the service (see {@link Type#getInternalName()}).
+   * @param providers the internal names (see {@link Type#getInternalName()}) of the implementations
+   *     of the service (there is at least one provider).
    */
   public void visitProvide(final String service, final String... providers) {
     if (mv != null) {

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/Opcodes.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/Opcodes.java
@@ -283,6 +283,11 @@ public interface Opcodes {
   int V15 = 0 << 16 | 59;
   int V16 = 0 << 16 | 60;
   int V17 = 0 << 16 | 61;
+  int V18 = 0 << 16 | 62;
+  int V19 = 0 << 16 | 63;
+  int V20 = 0 << 16 | 64;
+  int V21 = 0 << 16 | 65;
+  int V22 = 0 << 16 | 66;
 
   /**
    * Version flag indicating that the class is using 'preview' features.

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/RecordComponentVisitor.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/RecordComponentVisitor.java
@@ -45,7 +45,7 @@ public abstract class RecordComponentVisitor {
   /**
    * The record visitor to which this visitor must delegate method calls. May be {@literal null}.
    */
-  /*package-private*/ RecordComponentVisitor delegate;
+  protected RecordComponentVisitor delegate;
 
   /**
    * Constructs a new {@link RecordComponentVisitor}.
@@ -53,7 +53,7 @@ public abstract class RecordComponentVisitor {
    * @param api the ASM API version implemented by this visitor. Must be one of {@link Opcodes#ASM8}
    *     or {@link Opcodes#ASM9}.
    */
-  public RecordComponentVisitor(final int api) {
+  protected RecordComponentVisitor(final int api) {
     this(api, null);
   }
 
@@ -64,7 +64,7 @@ public abstract class RecordComponentVisitor {
    * @param recordComponentVisitor the record component visitor to which this visitor must delegate
    *     method calls. May be null.
    */
-  public RecordComponentVisitor(
+  protected RecordComponentVisitor(
       final int api, final RecordComponentVisitor recordComponentVisitor) {
     if (api != Opcodes.ASM9
         && api != Opcodes.ASM8
@@ -85,7 +85,8 @@ public abstract class RecordComponentVisitor {
   /**
    * The record visitor to which this visitor must delegate method calls. May be {@literal null}.
    *
-   * @return the record visitor to which this visitor must delegate method calls or {@literal null}.
+   * @return the record visitor to which this visitor must delegate method calls, or {@literal
+   *     null}.
    */
   public RecordComponentVisitor getDelegate() {
     return delegate;

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/RecordComponentWriter.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/RecordComponentWriter.java
@@ -37,7 +37,7 @@ final class RecordComponentWriter extends RecordComponentVisitor {
   /** The name_index field of the Record attribute. */
   private final int nameIndex;
 
-  /** The descriptor_index field of the the Record attribute. */
+  /** The descriptor_index field of the Record attribute. */
   private final int descriptorIndex;
 
   /**

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/Symbol.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/Symbol.java
@@ -103,12 +103,25 @@ abstract class Symbol {
   static final int TYPE_TAG = 128;
 
   /**
-   * The tag value of an {@link Frame#ITEM_UNINITIALIZED} type entry in the type table of a class.
+   * The tag value of an uninitialized type entry in the type table of a class. This type is used
+   * for the normal case where the NEW instruction is before the &lt;init&gt; constructor call (in
+   * bytecode offset order), i.e. when the label of the NEW instruction is resolved when the
+   * constructor call is visited. If the NEW instruction is after the constructor call, use the
+   * {@link #FORWARD_UNINITIALIZED_TYPE_TAG} tag value instead.
    */
   static final int UNINITIALIZED_TYPE_TAG = 129;
 
+  /**
+   * The tag value of an uninitialized type entry in the type table of a class. This type is used
+   * for the unusual case where the NEW instruction is after the &lt;init&gt; constructor call (in
+   * bytecode offset order), i.e. when the label of the NEW instruction is not resolved when the
+   * constructor call is visited. If the NEW instruction is before the constructor call, use the
+   * {@link #UNINITIALIZED_TYPE_TAG} tag value instead.
+   */
+  static final int FORWARD_UNINITIALIZED_TYPE_TAG = 130;
+
   /** The tag value of a merged type entry in the (ASM specific) type table of a class. */
-  static final int MERGED_TYPE_TAG = 130;
+  static final int MERGED_TYPE_TAG = 131;
 
   // Instance fields.
 
@@ -151,8 +164,8 @@ abstract class Symbol {
    *       #CONSTANT_INVOKE_DYNAMIC_TAG} symbols,
    *   <li>an arbitrary string for {@link #CONSTANT_UTF8_TAG} and {@link #CONSTANT_STRING_TAG}
    *       symbols,
-   *   <li>an internal class name for {@link #CONSTANT_CLASS_TAG}, {@link #TYPE_TAG} and {@link
-   *       #UNINITIALIZED_TYPE_TAG} symbols,
+   *   <li>an internal class name for {@link #CONSTANT_CLASS_TAG}, {@link #TYPE_TAG}, {@link
+   *       #UNINITIALIZED_TYPE_TAG} and {@link #FORWARD_UNINITIALIZED_TYPE_TAG} symbols,
    *   <li>{@literal null} for the other types of symbol.
    * </ul>
    */
@@ -172,6 +185,9 @@ abstract class Symbol {
    *       {@link #CONSTANT_DYNAMIC_TAG} or {@link #BOOTSTRAP_METHOD_TAG} symbols,
    *   <li>the bytecode offset of the NEW instruction that created an {@link
    *       Frame#ITEM_UNINITIALIZED} type for {@link #UNINITIALIZED_TYPE_TAG} symbols,
+   *   <li>the index of the {@link Label} (in the {@link SymbolTable#labelTable} table) of the NEW
+   *       instruction that created an {@link Frame#ITEM_UNINITIALIZED} type for {@link
+   *       #FORWARD_UNINITIALIZED_TYPE_TAG} symbols,
    *   <li>the indices (in the class' type table) of two {@link #TYPE_TAG} source types for {@link
    *       #MERGED_TYPE_TAG} symbols,
    *   <li>0 for the other types of symbol.

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/Type.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/Type.java
@@ -245,7 +245,7 @@ public final class Type {
   /**
    * Returns the {@link Type} corresponding to the given internal name.
    *
-   * @param internalName an internal name.
+   * @param internalName an internal name (see {@link Type#getInternalName()}).
    * @return the {@link Type} corresponding to the given internal name.
    */
   public static Type getObjectType(final String internalName) {
@@ -295,26 +295,12 @@ public final class Type {
    */
   public static Type[] getArgumentTypes(final String methodDescriptor) {
     // First step: compute the number of argument types in methodDescriptor.
-    int numArgumentTypes = 0;
-    // Skip the first character, which is always a '('.
-    int currentOffset = 1;
-    // Parse the argument types, one at a each loop iteration.
-    while (methodDescriptor.charAt(currentOffset) != ')') {
-      while (methodDescriptor.charAt(currentOffset) == '[') {
-        currentOffset++;
-      }
-      if (methodDescriptor.charAt(currentOffset++) == 'L') {
-        // Skip the argument descriptor content.
-        int semiColumnOffset = methodDescriptor.indexOf(';', currentOffset);
-        currentOffset = Math.max(currentOffset, semiColumnOffset + 1);
-      }
-      ++numArgumentTypes;
-    }
+    int numArgumentTypes = getArgumentCount(methodDescriptor);
 
     // Second step: create a Type instance for each argument type.
     Type[] argumentTypes = new Type[numArgumentTypes];
     // Skip the first character, which is always a '('.
-    currentOffset = 1;
+    int currentOffset = 1;
     // Parse and create the argument types, one at each loop iteration.
     int currentArgumentTypeIndex = 0;
     while (methodDescriptor.charAt(currentOffset) != ')') {
@@ -440,7 +426,7 @@ public final class Type {
       case '(':
         return new Type(METHOD, descriptorBuffer, descriptorBegin, descriptorEnd);
       default:
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("Invalid descriptor: " + descriptorBuffer);
     }
   }
 
@@ -703,13 +689,51 @@ public final class Type {
   }
 
   /**
+   * Returns the number of arguments of this method type. This method should only be used for method
+   * types.
+   *
+   * @return the number of arguments of this method type. Each argument counts for 1, even long and
+   *     double ones. The implicit @literal{this} argument is not counted.
+   */
+  public int getArgumentCount() {
+    return getArgumentCount(getDescriptor());
+  }
+
+  /**
+   * Returns the number of arguments in the given method descriptor.
+   *
+   * @param methodDescriptor a method descriptor.
+   * @return the number of arguments in the given method descriptor. Each argument counts for 1,
+   *     even long and double ones. The implicit @literal{this} argument is not counted.
+   */
+  public static int getArgumentCount(final String methodDescriptor) {
+    int argumentCount = 0;
+    // Skip the first character, which is always a '('.
+    int currentOffset = 1;
+    // Parse the argument types, one at a each loop iteration.
+    while (methodDescriptor.charAt(currentOffset) != ')') {
+      while (methodDescriptor.charAt(currentOffset) == '[') {
+        currentOffset++;
+      }
+      if (methodDescriptor.charAt(currentOffset++) == 'L') {
+        // Skip the argument descriptor content.
+        int semiColumnOffset = methodDescriptor.indexOf(';', currentOffset);
+        currentOffset = Math.max(currentOffset, semiColumnOffset + 1);
+      }
+      ++argumentCount;
+    }
+    return argumentCount;
+  }
+
+  /**
    * Returns the size of the arguments and of the return value of methods of this type. This method
    * should only be used for method types.
    *
    * @return the size of the arguments of the method (plus one for the implicit this argument),
    *     argumentsSize, and the size of its return value, returnSize, packed into a single int i =
    *     {@code (argumentsSize &lt;&lt; 2) | returnSize} (argumentsSize is therefore equal to {@code
-   *     i &gt;&gt; 2}, and returnSize to {@code i &amp; 0x03}).
+   *     i &gt;&gt; 2}, and returnSize to {@code i &amp; 0x03}). Long and double values have size 2,
+   *     the others have size 1.
    */
   public int getArgumentsAndReturnSizes() {
     return getArgumentsAndReturnSizes(getDescriptor());
@@ -722,7 +746,8 @@ public final class Type {
    * @return the size of the arguments of the method (plus one for the implicit this argument),
    *     argumentsSize, and the size of its return value, returnSize, packed into a single int i =
    *     {@code (argumentsSize &lt;&lt; 2) | returnSize} (argumentsSize is therefore equal to {@code
-   *     i &gt;&gt; 2}, and returnSize to {@code i &amp; 0x03}).
+   *     i &gt;&gt; 2}, and returnSize to {@code i &amp; 0x03}). Long and double values have size 2,
+   *     the others have size 1.
    */
   public static int getArgumentsAndReturnSizes(final String methodDescriptor) {
     int argumentsSize = 1;

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/signature/SignatureReader.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/signature/SignatureReader.java
@@ -54,9 +54,9 @@ public class SignatureReader {
    * Makes the given visitor visit the signature of this {@link SignatureReader}. This signature is
    * the one specified in the constructor (see {@link #SignatureReader}). This method is intended to
    * be called on a {@link SignatureReader} that was created using a <i>ClassSignature</i> (such as
-   * the <code>signature</code> parameter of the {@link org.objectweb.asm.ClassVisitor#visit}
+   * the <code>signature</code> parameter of the {@link org.ekstazi.asm.ClassVisitor#visit}
    * method) or a <i>MethodSignature</i> (such as the <code>signature</code> parameter of the {@link
-   * org.objectweb.asm.ClassVisitor#visitMethod} method).
+   * org.ekstazi.asm.ClassVisitor#visitMethod} method).
    *
    * @param signatureVistor the visitor that must visit this signature.
    */
@@ -131,8 +131,8 @@ public class SignatureReader {
    * the one specified in the constructor (see {@link #SignatureReader}). This method is intended to
    * be called on a {@link SignatureReader} that was created using a <i>JavaTypeSignature</i>, such
    * as the <code>signature</code> parameter of the {@link
-   * org.objectweb.asm.ClassVisitor#visitField} or {@link
-   * org.objectweb.asm.MethodVisitor#visitLocalVariable} methods.
+   * org.ekstazi.asm.ClassVisitor#visitField} or {@link
+   * org.ekstazi.asm.MethodVisitor#visitLocalVariable} methods.
    *
    * @param signatureVisitor the visitor that must visit this signature.
    */

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/signature/SignatureVisitor.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/signature/SignatureVisitor.java
@@ -6,13 +6,13 @@
 // modification, are permitted provided that the following conditions
 // are met:
 // 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
+// notice, this list of conditions and the following disclaimer.
 // 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
 // 3. Neither the name of the copyright holders nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -60,18 +60,18 @@ public abstract class SignatureVisitor {
   public static final char INSTANCEOF = '=';
 
   /**
-   * The ASM API version implemented by this visitor. The value of this field must be one of {@link
-   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+   * The ASM API version implemented by this visitor. The value of this field must be one of the
+   * {@code ASM}<i>x</i> values in {@link Opcodes}.
    */
   protected final int api;
 
   /**
    * Constructs a new {@link SignatureVisitor}.
    *
-   * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+   * @param api the ASM API version implemented by this visitor. Must be one of the {@code
+   *     ASM}<i>x</i> values in {@link Opcodes}.
    */
-  public SignatureVisitor(final int api) {
+  protected SignatureVisitor(final int api) {
     if (api != Opcodes.ASM9
         && api != Opcodes.ASM8
         && api != Opcodes.ASM7
@@ -180,7 +180,8 @@ public abstract class SignatureVisitor {
   /**
    * Starts the visit of a signature corresponding to a class or interface type.
    *
-   * @param name the internal name of the class or interface.
+   * @param name the internal name of the class or interface (see {@link
+   *     org.ekstazi.asm.Type#getInternalName()}).
    */
   public void visitClassType(final String name) {}
 

--- a/org.ekstazi.core/src/main/java/org/ekstazi/asm/signature/SignatureWriter.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/asm/signature/SignatureWriter.java
@@ -41,7 +41,7 @@ import org.ekstazi.asm.Opcodes;
 public class SignatureWriter extends SignatureVisitor {
 
   /** The builder used to construct the visited signature. */
-  private final StringBuilder stringBuilder = new StringBuilder();
+  private final StringBuilder stringBuilder;
 
   /** Whether the visited signature contains formal type parameters. */
   private boolean hasFormals;
@@ -51,8 +51,9 @@ public class SignatureWriter extends SignatureVisitor {
 
   /**
    * The stack used to keep track of class types that have arguments. Each element of this stack is
-   * a boolean encoded in one bit. The top of the stack is the least significant bit. Pushing false
-   * = *2, pushing true = *2+1, popping = /2.
+   * a boolean encoded in one bit. The top of the stack is the least significant bit. The bottom of
+   * the stack is a sentinel element always equal to 1 (used to detect when the stack is full).
+   * Pushing false = {@code <<= 1}, pushing true = {@code ( <<= 1) | 1}, popping = {@code >>>= 1}.
    *
    * <p>Class type arguments must be surrounded with '&lt;' and '&gt;' and, because
    *
@@ -62,15 +63,20 @@ public class SignatureWriter extends SignatureVisitor {
    *       SignatureWriter instances),
    * </ol>
    *
-   * <p>we need a stack to properly balance these 'parentheses'. A new element is pushed on this
-   * stack for each new visited type, and popped when the visit of this type ends (either is
+   * <p>we need a stack to properly balance these angle brackets. A new element is pushed on this
+   * stack for each new visited type, and popped when the visit of this type ends (either in
    * visitEnd, or because visitInnerClassType is called).
    */
-  private int argumentStack;
+  private int argumentStack = 1;
 
   /** Constructs a new {@link SignatureWriter}. */
   public SignatureWriter() {
+    this(new StringBuilder());
+  }
+
+  private SignatureWriter(final StringBuilder stringBuilder) {
     super(/* latest api =*/ Opcodes.ASM9);
+    this.stringBuilder = stringBuilder;
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -159,7 +165,7 @@ public class SignatureWriter extends SignatureVisitor {
     stringBuilder.append(name);
     // Pushes 'false' on the stack, meaning that this type does not have type arguments (as far as
     // we can tell at this point).
-    argumentStack *= 2;
+    argumentStack <<= 1;
   }
 
   @Override
@@ -169,7 +175,7 @@ public class SignatureWriter extends SignatureVisitor {
     stringBuilder.append(name);
     // Pushes 'false' on the stack, meaning that this type does not have type arguments (as far as
     // we can tell at this point).
-    argumentStack *= 2;
+    argumentStack <<= 1;
   }
 
   @Override
@@ -177,7 +183,7 @@ public class SignatureWriter extends SignatureVisitor {
     // If the top of the stack is 'false', this means we are visiting the first type argument of the
     // currently visited type. We therefore need to append a '<', and to replace the top stack
     // element with 'true' (meaning that the current type does have type arguments).
-    if (argumentStack % 2 == 0) {
+    if ((argumentStack & 1) == 0) {
       argumentStack |= 1;
       stringBuilder.append('<');
     }
@@ -189,14 +195,15 @@ public class SignatureWriter extends SignatureVisitor {
     // If the top of the stack is 'false', this means we are visiting the first type argument of the
     // currently visited type. We therefore need to append a '<', and to replace the top stack
     // element with 'true' (meaning that the current type does have type arguments).
-    if (argumentStack % 2 == 0) {
+    if ((argumentStack & 1) == 0) {
       argumentStack |= 1;
       stringBuilder.append('<');
     }
     if (wildcard != '=') {
       stringBuilder.append(wildcard);
     }
-    return this;
+    // If the stack is full, start a nested one by returning a new SignatureWriter.
+    return (argumentStack & (1 << 31)) == 0 ? this : new SignatureWriter(stringBuilder);
   }
 
   @Override
@@ -232,9 +239,9 @@ public class SignatureWriter extends SignatureVisitor {
     // If the top of the stack is 'true', this means that some type arguments have been visited for
     // the type whose visit is now ending. We therefore need to append a '>', and to pop one element
     // from the stack.
-    if (argumentStack % 2 == 1) {
+    if ((argumentStack & 1) == 1) {
       stringBuilder.append('>');
     }
-    argumentStack /= 2;
+    argumentStack >>>= 1;
   }
 }

--- a/org.ekstazi.core/src/main/java/org/ekstazi/instrument/CoverageClassVisitor.java
+++ b/org.ekstazi.core/src/main/java/org/ekstazi/instrument/CoverageClassVisitor.java
@@ -56,7 +56,7 @@ public class CoverageClassVisitor extends ClassVisitor {
     // Java 23 67.0
 
     /** Max supported Java class file version */
-    protected final int MAX_SUPPORTED_JAVA_VERSION = 61;
+    protected final int MAX_SUPPORTED_JAVA_VERSION = 65;
 
     // TODO: Revisit the need for this var.
     /** Support for old Java version */


### PR DESCRIPTION
This PR includes `85cf1aeb` ASM which is 9_6 that is needed for us to support Java 21.